### PR TITLE
Made timer go black at the start of void sea

### DIFF
--- a/assets/modinfo.json
+++ b/assets/modinfo.json
@@ -1,7 +1,7 @@
 {
 	"id": "speedruntimerfix",
 	"name": "Speedrun Timer Tweaks",
-	"version": "3.1.0",
+	"version": "3.1.1",
 	"authors": "forthbridge",
 	"description": "Adds some additional customization options to the built-in speedrun timer!<LINE><LINE>This mod used to improve the IGT before it was integrated into the base game - it is still compatible with 1.9.07b, and retains its original function when using that version.",
 	"tags": ["Accessibility", "Tools"],

--- a/src/Hooks/TimerDisplayHooks.cs
+++ b/src/Hooks/TimerDisplayHooks.cs
@@ -44,11 +44,11 @@ public static partial class Hooks
 
         var additionalTimersShown = 0;
 
+        var game = Utils.RainWorldGame;
+
 
         if (ModOptions.ShowOldTimer.Value)
         {
-            var game = Utils.RainWorldGame;
-
             if (game != null && game.IsStorySession)
             {
                 var oldTime = game.GetStorySession.saveState.totTime
@@ -73,8 +73,6 @@ public static partial class Hooks
 
         if (ModOptions.ShowTotTime.Value)
         {
-            var game = Utils.RainWorldGame;
-
             if (game != null && game.IsStorySession)
             {
                 var totTime = game.GetStorySession.saveState.totTime
@@ -101,7 +99,25 @@ public static partial class Hooks
             self.fade = 1.0f;
         }
 
-        self.timeLabel.color = ModOptions.TimerColor.Value;
+        if (game != null)
+        {
+            if (game.cameras[0].voidSeaMode && game.StoryCharacter != MoreSlugcatsEnums.SlugcatStatsName.Saint)
+            {
+                Player player = game.Players[0].realizedCreature as Player;
+                if (player.mainBodyChunk.pos.y > -3000)
+                {
+                    self.timeLabel.color = Color.black;
+                }
+                else
+                {
+                    self.timeLabel.color = ModOptions.TimerColor.Value;
+                }
+            }
+            else
+            {
+                self.timeLabel.color = ModOptions.TimerColor.Value;
+            }
+        }
 
 
         var screenSize = self.hud.rainWorld.options.ScreenSize;


### PR DESCRIPTION
Made timer go black when entering the void sea for better legibility. Only notable change is in TimerDisplayHooks.cs. Did not rebuild.